### PR TITLE
Proposal: Add support for Filaments `MaxWidth` enum

### DIFF
--- a/src/Livewire/RecentlyMenu.php
+++ b/src/Livewire/RecentlyMenu.php
@@ -4,6 +4,7 @@ namespace Awcodes\Recently\Livewire;
 
 use Awcodes\Recently\Models\RecentEntry;
 use Awcodes\Recently\RecentlyPlugin;
+use Filament\Support\Enums\MaxWidth;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Component;
@@ -20,7 +21,7 @@ class RecentlyMenu extends Component
 
     public ?string $icon = null;
 
-    public ?string $width = null;
+    public MaxWidth | null | string $width = null;
 
     public function mount(): void
     {

--- a/src/RecentlyPlugin.php
+++ b/src/RecentlyPlugin.php
@@ -8,6 +8,7 @@ use Closure;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
+use Filament\Support\Enums\MaxWidth;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Support\Facades\Blade;
 use Livewire\Livewire;
@@ -26,7 +27,7 @@ class RecentlyPlugin implements Plugin
 
     protected string | Closure | null $icon = null;
 
-    protected string | Closure | null $width = null;
+    protected MaxWidth | string | Closure | null $width = null;
 
     protected int | Closure | null $maxItems = null;
 
@@ -119,7 +120,7 @@ class RecentlyPlugin implements Plugin
         return $this;
     }
 
-    public function width(string | Closure $width): static
+    public function width(MaxWidth | string | Closure $width): static
     {
         $this->width = $width;
 
@@ -160,7 +161,7 @@ class RecentlyPlugin implements Plugin
         return $this->evaluate($this->maxItems) ?? config('recently.max_items');
     }
 
-    public function getWidth(): string
+    public function getWidth(): MaxWidth | string
     {
         return $this->evaluate($this->width) ?? config('recently.width');
     }

--- a/tests/src/PluginTest.php
+++ b/tests/src/PluginTest.php
@@ -5,8 +5,9 @@ use Awcodes\Recently\RecentlyPlugin;
 use Awcodes\Recently\Resources\RecentEntryResource;
 use Awcodes\Recently\Tests\Models\User;
 use Filament\Facades\Filament;
+    use Filament\Support\Enums\MaxWidth;
 
-it('registers plugin', function () {
+    it('registers plugin', function () {
     $panel = Filament::getCurrentPanel();
 
     $panel->plugins([
@@ -56,6 +57,8 @@ it('can modify width', function ($width) {
 })->with([
     'sm',
     fn () => 'xl',
+    MaxWidth::ExtraSmall,
+    fn () => MaxWidth::FourExtraLarge,
 ]);
 
 it('can modify max items', function ($items) {

--- a/tests/src/PluginTest.php
+++ b/tests/src/PluginTest.php
@@ -5,9 +5,9 @@ use Awcodes\Recently\RecentlyPlugin;
 use Awcodes\Recently\Resources\RecentEntryResource;
 use Awcodes\Recently\Tests\Models\User;
 use Filament\Facades\Filament;
-    use Filament\Support\Enums\MaxWidth;
+use Filament\Support\Enums\MaxWidth;
 
-    it('registers plugin', function () {
+it('registers plugin', function () {
     $panel = Filament::getCurrentPanel();
 
     $panel->plugins([


### PR DESCRIPTION
This PR adds support for Filaments `MaxWidth::class` enum.

You could do something like this before: 

```php
RecentlyPlugin::make()
  ->width(fn () => MaxWidth::ThreeExtraLarge->value)
```

Now you could do:
```php
RecentlyPlugin::make()
  ->width(MaxWidth::ThreeExtraLarge)
```

Before: 
![Screenshot 2024-10-02 121447](https://github.com/user-attachments/assets/014eb59e-771c-4eba-ae5d-fefa7ed27b56)

After:
![Screenshot 2024-10-02 121322](https://github.com/user-attachments/assets/2a2bf32a-9eea-4547-acf7-c43ec45f59a8)

Just an idea, let me know what you think. 🤓