### PR TITLE
Exclude deleted records from recent history

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ php artisan recently:install
 ``` 
 
 > [!IMPORTANT]
+> **Upgrading an existing installation?** Publish and run the new migration so recent entries can reference their record (this powers automatic filtering of deleted records):
+> ```bash
+> php artisan vendor:publish --tag="recently-migrations"
+> php artisan migrate
+> ```
+
+> [!IMPORTANT]
 > If you have not set up a custom theme and are using Filament Panels follow the instructions in the [Filament Docs](https://filamentphp.com/docs/4.x/styling/overview#creating-a-custom-theme) first.
 
 After setting up a custom theme add the plugin's views to your theme css file or your app's css file if using the standalone packages.
@@ -93,6 +100,10 @@ class ViewUser extends ViewRecord
     protected static string $resource = UserResource::class;
 }
 ```
+
+### Deleted Records
+
+Recent entries are automatically hidden from the menu and global search once the record they point to no longer exists — including soft-deleted records — so users never follow a stale link to a "Record not found" page. Each entry stores a polymorphic `recordable` reference to its record, and only entries whose record still resolves are displayed. Entries recorded for pages without an underlying record are always kept.
 
 ## Configuration
 You can enable/disable or customize the plugin's features either globally through the `config` file or per panel.

--- a/database/migrations/add_recordable_to_recent_entries_table.php.stub
+++ b/database/migrations/add_recordable_to_recent_entries_table.php.stub
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('recent_entries', function (Blueprint $table) {
+            $table->nullableMorphs('recordable');
+        });
+    }
+};

--- a/src/Concerns/HasRecentHistoryRecorder.php
+++ b/src/Concerns/HasRecentHistoryRecorder.php
@@ -40,6 +40,7 @@ trait HasRecentHistoryRecorder
             url: request()->url(),
             icon: $resource::getNavigationIcon(),
             title: strip_tags((string) $title),
+            record: $record,
         );
     }
 

--- a/src/Facades/Recently.php
+++ b/src/Facades/Recently.php
@@ -7,7 +7,7 @@ namespace Awcodes\Recently\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static void add(string $url, string $icon, string $title)
+ * @method static void add(string $url, string|\BackedEnum|null $icon, string $title, ?\Illuminate\Database\Eloquent\Model $record = null)
  *
  * @see \Awcodes\Recently\Recently
  */

--- a/src/Livewire/RecentlyMenu.php
+++ b/src/Livewire/RecentlyMenu.php
@@ -51,6 +51,7 @@ class RecentlyMenu extends Component
         $model = config('recently.model');
 
         $this->records = $model::query()
+            ->existing()
             ->orderByDesc('updated_at')
             ->limit($this->maxItems)
             ->get();

--- a/src/Models/RecentEntry.php
+++ b/src/Models/RecentEntry.php
@@ -8,9 +8,11 @@ use Awcodes\Recently\Database\Factories\RecentEntryFactory;
 use Awcodes\Recently\Models\Scopes\RecentEntryScope;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**
  * @property-read int $id
@@ -18,6 +20,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $url
  * @property string|null $icon
  * @property string|null $title
+ * @property string|null $recordable_type
+ * @property int|string|null $recordable_id
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
  */
@@ -31,11 +35,33 @@ class RecentEntry extends Model
         'url',
         'icon',
         'title',
+        'recordable_type',
+        'recordable_id',
     ];
 
     public function user(): BelongsTo
     {
         return $this->belongsTo(config('recently.user_model'));
+    }
+
+    public function recordable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Limit to entries that still point at a live record — i.e. those with no
+     * record reference (e.g. non-record pages), or whose referenced record
+     * still exists. A soft-deleted or hard-deleted record fails the morph
+     * existence check and is excluded.
+     */
+    public function scopeExisting(Builder $query): void
+    {
+        $query->where(function (Builder $query): void {
+            $query
+                ->whereNull('recordable_type')
+                ->orWhereHasMorph('recordable', '*');
+        });
     }
 
     protected static function newFactory(): RecentEntryFactory

--- a/src/Recently.php
+++ b/src/Recently.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Recently
 {
-    public function add(string $url, string|BackedEnum|null $icon, string $title): void
+    public function add(string $url, string|BackedEnum|null $icon, string $title, ?Model $record = null): void
     {
         if ($icon instanceof Heroicon) {
             $icon = "heroicon-$icon->value";
@@ -28,6 +28,8 @@ class Recently
             'url' => $url,
             'icon' => $icon ?? '',
             'title' => $title,
+            'recordable_type' => $record?->getMorphClass(),
+            'recordable_id' => $record?->getKey(),
         ]);
     }
 }

--- a/src/RecentlyServiceProvider.php
+++ b/src/RecentlyServiceProvider.php
@@ -44,6 +44,7 @@ class RecentlyServiceProvider extends PackageServiceProvider
     {
         return [
             'create_recently_table',
+            'add_recordable_to_recent_entries_table',
         ];
     }
 }

--- a/src/Resources/RecentEntryResource.php
+++ b/src/Resources/RecentEntryResource.php
@@ -6,6 +6,7 @@ namespace Awcodes\Recently\Resources;
 
 use Awcodes\Recently\RecentlyPlugin;
 use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 class RecentEntryResource extends Resource
@@ -19,6 +20,11 @@ class RecentEntryResource extends Resource
     public static function getModel(): string
     {
         return config('recently.model');
+    }
+
+    public static function getGlobalSearchEloquentQuery(): Builder
+    {
+        return parent::getGlobalSearchEloquentQuery()->existing();
     }
 
     public static function getGlobalSearchResultUrl(Model $record): ?string

--- a/tests/database/migrations/create_pages_table.php
+++ b/tests/database/migrations/create_pages_table.php
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->longText('content')->nullable();
 
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 };

--- a/tests/database/migrations/create_recent_entries_table.php
+++ b/tests/database/migrations/create_recent_entries_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->text('url');
             $table->string('icon');
             $table->string('title');
+            $table->nullableMorphs('recordable');
 
             $table->timestamps();
         });

--- a/tests/src/DeletedRecordsTest.php
+++ b/tests/src/DeletedRecordsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Awcodes\Recently\Livewire\RecentlyMenu;
+use Awcodes\Recently\Models\RecentEntry;
+use Awcodes\Recently\RecentlyPlugin;
+use Awcodes\Recently\Resources\RecentEntryResource;
+use Awcodes\Recently\Tests\Models\Page;
+use Awcodes\Recently\Tests\Models\User;
+use Awcodes\Recently\Tests\Resources\Pages\PageResource;
+use Filament\Facades\Filament;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+
+    $this->panel = Filament::getCurrentOrDefaultPanel();
+    $this->panel->plugins([RecentlyPlugin::make()]);
+
+    $this->plugin = Filament::getPlugin('awcodes/recently');
+});
+
+it('stores a polymorphic reference to the viewed record', function () {
+    $page = Page::factory()->create();
+    $url = PageResource::getUrl('edit', ['record' => $page]);
+
+    $this->get($url)->assertSuccessful();
+
+    $this->assertDatabaseHas(RecentEntry::class, [
+        'url' => $url,
+        'recordable_type' => $page->getMorphClass(),
+        'recordable_id' => $page->getKey(),
+    ]);
+});
+
+it('hides entries whose record has been deleted, keeping live and reference-less ones', function () {
+    $page = Page::factory()->create();
+    $url = PageResource::getUrl('edit', ['record' => $page]);
+    $this->get($url)->assertSuccessful();
+
+    // an entry that points at nothing (no record reference) must always survive
+    RecentEntry::create([
+        'user_id' => $this->user->id,
+        'url' => 'https://example.test/legacy',
+        'icon' => '',
+        'title' => 'Legacy',
+    ]);
+
+    expect(RecentEntry::existing()->pluck('url')->all())->toContain($url);
+
+    $page->delete();
+
+    expect(RecentEntry::existing()->pluck('url')->all())
+        ->not->toContain($url)
+        ->toContain('https://example.test/legacy');
+
+    // menu surface
+    $records = livewire(RecentlyMenu::class)->instance()->records;
+    expect($records->pluck('url')->all())->not->toContain($url);
+
+    // global-search surface
+    $searchUrls = RecentEntryResource::getGlobalSearchEloquentQuery()->pluck('url')->all();
+    expect($searchUrls)->not->toContain($url);
+});

--- a/tests/src/Models/Page.php
+++ b/tests/src/Models/Page.php
@@ -7,10 +7,12 @@ namespace Awcodes\Recently\Tests\Models;
 use Awcodes\Recently\Tests\Database\Factories\PageFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Page extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected $guarded = [];
 


### PR DESCRIPTION
## Problem

A `RecentEntry` stores only a URL, so the menu and the global-search "Recently" group keep listing records that have since been deleted. Clicking one lands the user on Filament's *"Record not found"* page. Any app using the plugin with deletable (including soft-deletable) records hits this.

## Change

- The recorder already holds the viewed `$record` and discarded it — it's now stored as a nullable polymorphic `recordable` reference on the entry. `add()` gains an optional `?Model $record`, plus a small backward-compatible migration.
- A new `existing()` scope on `RecentEntry` limits results to entries whose record still resolves — a `MorphTo` returns `null` for a soft-deleted or missing record. Both display surfaces apply it: the menu (`RecentlyMenu::getRecords()`) and global search (`RecentEntryResource::getGlobalSearchEloquentQuery()`).
- Entries with no record reference (e.g. non-record pages) are always kept, so pre-existing rows keep displaying.

## Notes

- **Backward compatible / SemVer-safe:** additive nullable columns, an optional parameter, and an opt-in scope. No public API broken.
- Existing installs run the published migration (`vendor:publish --tag="recently-migrations"` + `migrate`); README updated with an upgrade note and a "Deleted Records" section.
- **Tests added** (`tests/src/DeletedRecordsTest.php`): a soft-deleted record's entry is hidden from both surfaces while live and reference-less entries remain. `composer test` is green.
