### PR TITLE
Prune stored history to max_items per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ return [
 ];
 ```
 
+### Retention
+
+Only the most recent `max_items` entries per user are stored — as new records are viewed, older entries beyond that limit are pruned automatically. This keeps the `recent_entries` table bounded, so `max_items` caps stored history, not just what the menu displays.
+
 ### Global Search
 By default, the plugin will list the recent visits/views as part of the global search results. To disable this feature, set the `global_search` option to `false` from the config or by passing `false` to the `globalSearch()` method per panel.
 

--- a/src/Recently.php
+++ b/src/Recently.php
@@ -20,14 +20,39 @@ class Recently
         /** @var class-string<Model> $model */
         $model = config('recently.model');
 
+        $userId = Filament::auth()->user()->getAuthIdentifier();
+
         $model::updateOrCreate([
-            'user_id' => Filament::auth()->user()->getAuthIdentifier(),
+            'user_id' => $userId,
             'url' => $url,
         ], [
-            'user_id' => Filament::auth()->user()->getAuthIdentifier(),
+            'user_id' => $userId,
             'url' => $url,
             'icon' => $icon ?? '',
             'title' => $title,
         ]);
+
+        $this->prune($model, $userId);
+    }
+
+    /**
+     * Keep only the most-recent `recently.max_items` entries for the user.
+     * The table is otherwise unbounded — `max_items` caps the display, not storage.
+     *
+     * @param  class-string<Model>  $model
+     */
+    protected function prune(string $model, int|string $userId): void
+    {
+        $keepIds = $model::query()
+            ->where('user_id', $userId)
+            ->orderByDesc('updated_at')
+            ->orderByDesc('id') // deterministic tiebreak when timestamps collide
+            ->limit(config('recently.max_items'))
+            ->pluck('id');
+
+        $model::query()
+            ->where('user_id', $userId)
+            ->whereNotIn('id', $keepIds)
+            ->delete();
     }
 }

--- a/tests/src/RetentionTest.php
+++ b/tests/src/RetentionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Awcodes\Recently\Facades\Recently;
+use Awcodes\Recently\Models\RecentEntry;
+use Awcodes\Recently\RecentlyPlugin;
+use Awcodes\Recently\Tests\Models\User;
+use Filament\Facades\Filament;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+
+    $this->panel = Filament::getCurrentOrDefaultPanel();
+    $this->panel->plugins([RecentlyPlugin::make()]);
+});
+
+it('keeps only the most recent max_items entries per user', function () {
+    $max = config('recently.max_items');
+
+    for ($i = 0; $i < $max + 5; $i++) {
+        Recently::add("https://example.test/page/{$i}", '', "Page {$i}");
+    }
+
+    $stored = RecentEntry::withoutGlobalScopes()->where('user_id', $this->user->id);
+
+    expect($stored->count())->toBe($max)
+        // the most recently recorded url is kept; the oldest is dropped
+        ->and((clone $stored)->where('url', 'https://example.test/page/'.($max + 4))->exists())->toBeTrue()
+        ->and((clone $stored)->where('url', 'https://example.test/page/0')->exists())->toBeFalse();
+});
+
+it('prunes per user, leaving other users untouched', function () {
+    $max = config('recently.max_items');
+
+    $other = User::factory()->create();
+    RecentEntry::create([
+        'user_id' => $other->id,
+        'url' => 'https://example.test/other',
+        'icon' => '',
+        'title' => 'Other',
+    ]);
+
+    for ($i = 0; $i < $max + 3; $i++) {
+        Recently::add("https://example.test/page/{$i}", '', "Page {$i}");
+    }
+
+    expect(RecentEntry::withoutGlobalScopes()->where('user_id', $this->user->id)->count())->toBe($max)
+        ->and(RecentEntry::withoutGlobalScopes()->where('user_id', $other->id)->count())->toBe(1);
+});


### PR DESCRIPTION
## Problem

`Recently::add()` writes one row per (user, distinct URL) and never removes any. `max_items` only caps what the menu and global search *display*, so `recent_entries` grows unbounded — an active user accumulates a row for every distinct record they've ever viewed.

## Change

After recording an entry, prune the user's rows down to the most-recent `max_items` (the config value). Ties on `updated_at` are broken by `id` so the newest insert wins when timestamps collide. Pruning is scoped per user, so other users' history is untouched.

## Notes

- No public API change — `add()`'s signature is unchanged.
- Independent of any other change; based on `3.x`.
- **Tests added** (`tests/src/RetentionTest.php`): stored count stays at `max_items`, the oldest entry is dropped and the newest kept, and a second user's history is untouched. `composer test` is green.
- README updated with a "Retention" section.
