### PR TITLE
Support Filament v4 & v5 on one line + CI refresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.3
 
@@ -38,7 +38,7 @@ jobs:
         run: composer lint
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "Format Code"
           commit_user_name: 'GitHub Actions'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,38 +22,30 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.5, 8.4, 8.3]
-        laravel: [13.*, 12.*, 11.*]
+        php: [8.4, 8.3]
+        laravel: [13.*, 12.*]
         stability: [prefer-stable]
         include:
           - laravel: 13.*
             testbench: 11.*
-            carbon: 3.*
-            collision: 8.*
           - laravel: 12.*
             testbench: 10.*
-            carbon: 3.*
-            collision: 8.*
-          - laravel: 11.*
-            testbench: 9.*
-            carbon: 3.*
-            collision: 8.*
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache Dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo_sqlite
           coverage: none
 
       - name: Install Dependencies
@@ -63,7 +55,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" "nunomaduro/collision:${{ matrix.collision }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Easily track and access recently viewed records in your filament panels.
 |-----------------|------------------|
 | 1.x             | 3.x              |
 | 2.x             | 4.x              |
-| 3.x             | 5.x              |
+| 3.x             | 4.x & 5.x        |
 
 <!-- [docs_start] -->
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^5.0",
+        "filament/filament": "^4.0|^5.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {


### PR DESCRIPTION
Adds Filament 4 support to the shared 3.x line and standardizes CI.

## Shared Filament support
- Widen `filament/filament` to `^4.0|^5.0`.
- **recently skipped Filament 4** — both 2.x and 3.x shipped `^5.0` — so this *adds* F4 support it never offered. Verified safe by running the full suite against **Filament 4 / Livewire 3 (23 passed, 36 assertions)**.
- README 3.x compat row → `4.x & 5.x`.

Resolution: `--prefer-stable` → Filament 5 / Livewire 4; F4 install + tests confirmed locally.

## CI refresh
- Standardize `tests.yml` to the fleet template (drop PHP 8.5 / Laravel 11; PHP 8.3/8.4 × Laravel 12/13).
- Trim extensions, SHA-pin actions, add dependabot cooldown.

Ships as **v3.1.0**. Default branch already `3.x`.

> Out of scope / flagged: the README's `2.x → 4.x` row is inaccurate (2.x released `^5.0`), and there's a stray duplicate `2.x` branch. Left untouched per your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)