### PR TITLE
ci: trigger CI on workbench/ and bin/ changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
       - "resources/**"
       - "routes/**"
       - "tests/**"
+      # workbench/ is a tracked Testbench app that rector and phpstan analyse
+      # (.github#6), so a workbench-only commit must trigger CI. Without this it
+      # lands on the active branch unchecked and then fails the NEXT unrelated PR.
+      - "workbench/**"
       - "composer.json"
       - "composer.lock"
       - "package.json"
@@ -20,6 +24,9 @@ on:
       - "phpstan.neon*"
       - "rector.php"
       - "pint.json"
+      # bin/ holds the asset build script, so a change here changes the built
+      # bundle without touching resources/.
+      - "bin/**"
       - ".github/workflows/**"
   pull_request:
     branches:
@@ -31,6 +38,10 @@ on:
       - "resources/**"
       - "routes/**"
       - "tests/**"
+      # workbench/ is a tracked Testbench app that rector and phpstan analyse
+      # (.github#6), so a workbench-only commit must trigger CI. Without this it
+      # lands on the active branch unchecked and then fails the NEXT unrelated PR.
+      - "workbench/**"
       - "composer.json"
       - "composer.lock"
       - "package.json"
@@ -40,6 +51,9 @@ on:
       - "phpstan.neon*"
       - "rector.php"
       - "pint.json"
+      # bin/ holds the asset build script, so a change here changes the built
+      # bundle without touching resources/.
+      - "bin/**"
       - ".github/workflows/**"
 
 jobs:


### PR DESCRIPTION
## Problem

[.github#6](https://github.com/awcodes/.github/pull/6) put `workbench/` into rector's and phpstan's analysis paths. The caller's `paths` trigger filter was never updated to match, so the two halves disagree — the analysers police `workbench/`, but this workflow never fires when only `workbench/` changes.

The consequence is not "CI is skipped harmlessly": a workbench-only commit lands on the active branch **unchecked**, and the resulting `Static Analysis` / `Reformat` failure surfaces on the *next, unrelated* PR instead.

`bin/` has the same shape — it holds the asset build script, so a change there alters the built bundle without touching `resources/`, and neither CI nor a dist-freshness job would run.

## Change

Adds `workbench/**` and `bin/**` to both the `push` and `pull_request` `paths` filters, with comments explaining why. One file, +14/−0, no behaviour change to any job.

`bin/**` is included even where this package has no `bin/` directory, so every caller stays diffable against the template. A path filter for a directory that does not exist is inert.

## Verification

The YAML was parsed after patching and both entries confirmed present in the `push` and `pull_request` filters. Because this PR touches `.github/workflows/**`, it triggers the full check set itself.

Fixed upstream in [awcodes/.github#7](https://github.com/awcodes/.github/pull/7). These templates are copied per repo rather than consumed via `@v1`, so this backfill is applied to each of the 18 affected callers separately (`mason` and `richer-editor` already carry the lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QxdNSNdqXRproytP5odgW
