### PR TITLE
chore: bring rector's and phpstan's paths in line

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,9 @@ parameters:
         - src
         - workbench
         - config
+        # Migrations and factories are shipped code. phpstan flags wrong-arity
+        # Blueprint calls here — the class of bug postal-codes#12 turned out to be.
+        - database
     excludePaths:
         analyse:
             - workbench/storage (?)

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/workbench',
         __DIR__ . '/config',
+        __DIR__ . '/database',
     ])
     ->withSkip([
         __DIR__ . '/workbench/storage',


### PR DESCRIPTION
## Why

Pint already formats `database/` — the canonical `pint.json` declares no `exclude` — but phpstan and rector both listed `src` and `workbench` only. That is the same asymmetry [.github#6](https://github.com/awcodes/.github/pull/6) closed for `workbench/`: one of the four checks policing code the other two ignore.

**This is not hygiene.** Migrations and factories are shipped code, and phpstan's `arguments.count` check on them is precisely what would have caught [postal-codes#12](https://github.com/awcodes/postal-codes/issues/12):

```
$table->float('lat', 10, 8);   // Laravel 11+: float($column, $precision = 53)
```

PHP silently discards the extra positional argument, so the 8 decimal places vanished and the column lost precision on MySQL, PostgreSQL and SQL Server. Verified by temporarily restoring the buggy call and re-running:

```
Method Illuminate\Database\Schema\Blueprint::float() invoked with 3 parameters, 1-2 required.
  🪪  arguments.count
```

That is a **level-0** check. The bug shipped only because the directory was not in phpstan's paths.

## Cost

**Zero new baseline entries** — phpstan reports `[OK] No errors` across `src`, `workbench`, `config` and `database`.

## Verification

- `composer test` green: rector clean, pint clean, phpstan no errors, full suite passing.
- The rector pass was reviewed by hand rather than trusted, because `ClosureReturnTypeRector` is the rule implicated in [.github#8](https://github.com/awcodes/.github/issues/8) (rector and Pint silently mangling a fully-qualified union, with both tools then reporting clean). It emitted single `: array` return types here, not unions, so the trap had no surface. Pint then corrected `fn(` to `fn (` via `function_declaration`.
- `rand()` → `random_int()` in the factory is a genuine improvement, not just churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QxdNSNdqXRproytP5odgW
